### PR TITLE
Skip downloading images that already exist on disk

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,45 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+This is a Python CLI tool that exports iNaturalist observations to Ankivalenz-formatted Markdown flashcards. The tool fetches observations from the iNaturalist API, downloads images, and generates flashcard files for spaced repetition learning.
+
+## Architecture
+
+The codebase is organized into 3 main modules:
+
+- `api.py` - `INaturalistAPI` class handles API communication and image downloads
+- `markdown.py` - Functions for generating Ankivalenz-compatible Markdown format
+- `cli.py` - Click-based command-line interface that orchestrates the workflow
+
+The CLI workflow: fetch observations → download images to `iNaturalist/` directory → generate `iNaturalist.md` with flashcard format
+
+## Development Commands
+
+```bash
+# Set up development environment
+python -m venv venv
+source venv/bin/activate  # On Windows: venv\Scripts\activate
+pip install -e .
+
+# Run tests
+pytest
+
+# Run the CLI tool
+inaturalist-to-ankivalenz --username <username> [--limit <number>] [--output-dir <directory>] [--common-name-lang <language>]
+```
+
+## Dependencies
+
+- `requests` for API calls and image downloads
+- `click` for CLI interface
+- Uses `pathlib` for file system operations
+
+## Output Format
+
+The tool generates Ankivalenz flashcards in this format:
+```markdown
+- ![Common Name (Scientific Name)](iNaturalist/observation-ID.jpg) ?:: Common Name (Scientific Name)
+```

--- a/src/inaturalist_to_ankivalenz/api.py
+++ b/src/inaturalist_to_ankivalenz/api.py
@@ -35,17 +35,22 @@ class INaturalistAPI:
         if not observation.get("photos"):
             return None
 
+        output_dir = Path(output_dir)
+        output_dir.mkdir(parents=True, exist_ok=True)
+
+        image_path = output_dir / f"observation-{observation['id']}.jpg"
+        
+        # Check if image already exists on disk
+        if image_path.exists():
+            return image_path
+
         photo = observation["photos"][0]
         # Replace 'square' with 'medium' in the URL to get a larger image
         image_url = photo["url"].replace("square", "medium")
 
-        output_dir = Path(output_dir)
-        output_dir.mkdir(parents=True, exist_ok=True)
-
         response = requests.get(image_url)
         response.raise_for_status()
 
-        image_path = output_dir / f"observation-{observation['id']}.jpg"
         image_path.write_bytes(response.content)
 
         return image_path

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,69 @@
+"""Tests for API functionality."""
+
+import tempfile
+from pathlib import Path
+from unittest.mock import Mock, patch
+from inaturalist_to_ankivalenz.api import INaturalistAPI
+
+
+def test_download_observation_image_skips_existing_file():
+    """Test that download_observation_image skips downloading if file already exists."""
+    api = INaturalistAPI()
+    
+    # Sample observation data
+    observation = {
+        "id": 123,
+        "photos": [{"url": "http://example.com/photo-square.jpg"}]
+    }
+    
+    with tempfile.TemporaryDirectory() as temp_dir:
+        output_dir = Path(temp_dir)
+        image_path = output_dir / "observation-123.jpg"
+        
+        # Create the image file to simulate it already exists
+        image_path.write_text("existing image content")
+        original_content = image_path.read_text()
+        
+        # Mock requests.get to ensure it's not called
+        with patch('inaturalist_to_ankivalenz.api.requests.get') as mock_get:
+            result = api.download_observation_image(observation, output_dir)
+            
+            # Verify the existing file is returned
+            assert result == image_path
+            # Verify the content wasn't changed
+            assert image_path.read_text() == original_content
+            # Verify requests.get was not called
+            mock_get.assert_not_called()
+
+
+def test_download_observation_image_downloads_new_file():
+    """Test that download_observation_image downloads when file doesn't exist."""
+    api = INaturalistAPI()
+    
+    # Sample observation data
+    observation = {
+        "id": 456,
+        "photos": [{"url": "http://example.com/photo-square.jpg"}]
+    }
+    
+    with tempfile.TemporaryDirectory() as temp_dir:
+        output_dir = Path(temp_dir)
+        image_path = output_dir / "observation-456.jpg"
+        
+        # Ensure file doesn't exist
+        assert not image_path.exists()
+        
+        # Mock requests.get to simulate successful download
+        mock_response = Mock()
+        mock_response.content = b"downloaded image content"
+        mock_response.raise_for_status = Mock()
+        
+        with patch('inaturalist_to_ankivalenz.api.requests.get', return_value=mock_response) as mock_get:
+            result = api.download_observation_image(observation, output_dir)
+            
+            # Verify the file was created and returned
+            assert result == image_path
+            assert image_path.exists()
+            assert image_path.read_bytes() == b"downloaded image content"
+            # Verify requests.get was called with the medium URL
+            mock_get.assert_called_once_with("http://example.com/photo-medium.jpg")


### PR DESCRIPTION
## Summary
- Optimize image downloading by checking if files already exist before attempting download
- Add comprehensive test coverage for the new functionality

## Test plan
- [x] Run existing tests to ensure no regressions
- [x] Add new tests for both existing file scenarios and new download scenarios
- [x] Verify that existing images are not re-downloaded
- [x] Verify that new images are still downloaded correctly

🤖 Generated with [Claude Code](https://claude.ai/code)